### PR TITLE
Thread rething

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BIN_NAME := brimming
 ALL_ARCH := amd64 arm64
 ALL_OS := linux darwin
 
-all: fmt vet test build image
+all: fmt vet test build
 
 .PHONY: fmt
 fmt:
@@ -18,7 +18,12 @@ vet:
 test:
 	go test ./...
 
-build:
+.PHONY: clean
+clean:
+	@go clean
+
+.PHONY: build
+build: clean
 	@CGO_ENABLED=0 go build -ldflags "-s -X main.Version=${VERSION}" -o brimming
 
 .PHONY: image

--- a/README.md
+++ b/README.md
@@ -2,16 +2,52 @@
 
 Your MariaDB database will be brimming with data.
 
-Insert 1 billion rows into 100 tables, 10k batches a time, using 100 threads:
+Insert 1 billion rows into 100 tables, using 10,000 row batches, and 100 threads:
 
-    brimming -socket=/run/mysqld/mysqld.sock -rows=1000000000 -threads=100 -tables=100 -batch=100000
+    brimming --rows=1000000000 -threads=100 -tables=100 -batch=100000
 
-Each row is just over 1KB, 1 billion rows will generate around 1TB of data, exluding indexes!
+Alternatively specify the size of data you wish to insert, let's load 1TB:
 
-Alternatively specify the size of data you wish to insert:
+    brimming --size=1tb --threads=10 --tables=250
 
-    brimming -socket=/run/mysqld/mysqld.sock -size=1gb -threads=10 -tables=2
+## Usage
+Other than the usual options like username, password, port etc, all options are related to loading data.
+Pay attention to the defaults being populated, which can be reviewed in `brimming --help`.
 
-## Install
+The default database is called brim. The user will need permissions to create, drop, insert, select on all tables in database schema.
 
-    go get github.com/rcbensley/brimming
+* rows, as mentioned above use either rows or size to specify how much data you wish to load. Internally this is an Int64 value, so the sky's the limit!
+* size, internally this is converted into a row count. Each row is roughly 1kb. The option requires a size value followed by the type of unit size. For example, to insert 100mb, use `--size=100mb`.
+* tables, how many tables should the data be distributed over? If the batch size is too large, then not all the tables will be loaded.
+* batch, how many rows to insert into each table in each insert.
+* threads, ramp it up! Can be constrained using the `--connections` flag.
+* engine, use a different table engine should you wish.
+* connections, limit how many connections are opened to MariaDB.
+* skip-drop, do not drop any pre-existing tables.
+* skip-count, do not run a `count(*)` on each loaded table at the end of a run.
+
+## Data
+What is being loaded?
+Each row is just over 1KB, 1 billion rows will generate around 1TB of data, exluding indexes.
+Brimming does not use prepared statements. Just raw auto-committed, multi-value inserts.
+
+The tables are created in numerical order. If you are loading 10 tables, the tables brim1 to brim10 will be created, and dropped if they already exist (unless you are using `--skip-drop`).
+
+The table itself:
+
+	CREATE TABLE IF NOT EXISTS brim1 (
+	a bigint(20) NOT NULL AUTO_INCREMENT,
+	b int(11) NOT NULL,
+	c char(255) NOT NULL,
+	d char(255) NOT NULL,
+	e char(255) NOT NULL,
+	f char(255) NOT NULL,
+	PRIMARY KEY (a), INDEX (b)) ENGINE=InnoDB;
+
+Quite simple. The column, a, is left to be populated by `AUTO_INCREMENT`. All other fields are populated with randomly generated data in batches.
+
+
+## Considerations
+The default `max_packet_allowed` is about 16MB, so increase this as you increase your batch size. A warning will be generated if this value is exceeded.
+Do you have the general log or binary logging enabled?
+

--- a/README.md
+++ b/README.md
@@ -8,7 +8,14 @@ Insert 1 billion rows into 100 tables, using 10,000 row batches, and 100 threads
 
 Alternatively specify the size of data you wish to insert, let's load 1TB:
 
-    brimming --size=1tb --threads=10 --tables=250
+    brimming --size=1tb --threads=100 --tables=250
+
+## Install
+If you have go installed:
+
+	go install github.com/rcbensley/brimming@latest
+
+Otherwise checkout the package tarballs.
 
 ## Usage
 Other than the usual options like username, password, port etc, all options are related to loading data.

--- a/brimming.go
+++ b/brimming.go
@@ -8,173 +8,46 @@ import (
 	"os"
 	"os/user"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/alecthomas/kingpin"
 	_ "github.com/go-sql-driver/mysql"
 )
 
 var (
-	Version string = ""
+	Version           string = ""
+	defaultSocketPath string
+	defaultUserName   string
 )
 
 type brim struct {
 	dsn           string
 	db            *sql.DB
 	database      string
-	rows          int
-	batch         int
+	rows          int64
+	batch         int64
 	tables        int
 	threads       int
-	jobs          [][]int
 	tableBaseName string
 	engine        string
+	start         time.Time
 }
 
-func sizeToFloat(s string) (float64, error) {
-	ns := s[:len(s)-2]
-	n, err := strconv.ParseFloat(ns, 64)
-	if err != nil {
-		return 0, err
-	}
-	return n, nil
-}
-
-func sizeToRows(s string) (int, error) {
-	var m float64 = 1
-	re := regexp.MustCompile("(?i)[0-9]+[A-Za-z]+")
-	if !re.MatchString(s) {
-		return 0, fmt.Errorf("-size must be in format [number][size], e.g. 123gb")
-	}
-	size := strings.ToLower(s[len(s)-2:])
-
-	switch size {
-	case "mb":
-		m = 1000
-	case "gb":
-		m = 1000000
-	case "tb":
-		m = 1000000000
-	default:
-		return 0, fmt.Errorf("unknown -size %s. I can do mb, gb, and tb", s)
-	}
-
-	rows, err := sizeToFloat(s)
-	if err != nil {
-		return int(rows), err
-	}
-
-	rows = rows * m
-
-	return int(rows), nil
-}
-
-func randomString(r *rand.Rand) string {
-	var length int = 255
-	var characters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
-
-	s := make([]rune, length)
-	for i := range s {
-		s[i] = characters[r.Intn(len(characters))]
-	}
-	return string(s)
-}
-
-func generateRow() []string {
-	var limit = 2147483647
-	// 1000000000 x genRow ~= 1TB
-	r := rand.New(rand.NewSource(64))
-	b := strconv.Itoa(r.Intn(limit))
-	c := randomString(r)
-	d := randomString(r)
-	e := randomString(r)
-	f := randomString(r)
-	return []string{b, c, d, e, f}
-}
-
-func (b *brim) createDatabase() error {
-	log.Printf("Creating database %s\n", b.database)
-	create := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", b.database)
-	err := b.insertRow(create)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (b *brim) createTable(name string) error {
-	log.Printf("Creating table %s.%s\n", b.database, name)
-	create := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s.%s (
-a bigint(20) NOT NULL AUTO_INCREMENT,
-b int(11) NOT NULL,
-c char(255) NOT NULL,
-d char(255) NOT NULL,
-e char(255) NOT NULL,
-f char(255) NOT NULL,
-PRIMARY KEY (a),
-	INDEX (b)) ENGINE=%s;`, b.database, name, b.engine)
-	err := b.insertRow(create)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (b *brim) createTables() error {
-	for i := 1; i <= b.tables; i++ {
-		err := b.createTable(fmt.Sprintf("%s%d", b.tableBaseName, i))
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (b *brim) insertRow(query string) error {
-	_, err := b.db.Exec(query)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func generateBatch(rows int) [][]string {
-	batch := make([][]string, rows)
-	for i := range batch {
-		r := generateRow()
-		batch[i] = r
-	}
-	return batch
-}
-
-// Load table will generate a batch of data using generateRow and load the target table.
-func (b *brim) loadTable(stmt *sql.Stmt, rows int) error {
-	data := generateBatch(rows)
-	if _, err := stmt.Exec(data); err != nil {
-		return err
-	}
-	return nil
-}
-
-func NewBrim(username, password string, host string, port int, socket, database, engine, size string, rows, batch, tables, threads int) (*brim, error) {
+func NewBrim(username, password string, host string, port, connections int, socket, database, engine, size string, rows, batch int64, tables, threads int) (*brim, error) {
 	var (
-		defaultRows    int    = 1000000
-		defaultBatch   int    = 1000
+		defaultRows    int64  = 10000
+		defaultBatch   int64  = 1000
 		defaultTables  int    = 10
-		defaultThreads int    = 100
+		defaultThreads int    = 10
 		protocol       string = "unix"
 		dsnOptions     string = "?multiStatements=true&autocommit=true&maxAllowedPacket=0"
 		hostAndPort    string
 	)
-	if username == "" {
-		u, err := user.Current()
-		if err == nil {
-			username = u.Username
-		}
-	}
 
-	if host != "localhost" {
+	if host != "localhost" || socket == "" {
 		protocol = "tcp"
 		hostAndPort = fmt.Sprintf("%s:%d", host, port)
 	} else {
@@ -233,28 +106,192 @@ func NewBrim(username, password string, host string, port int, socket, database,
 		return nil, err
 	}
 
-	jobs := [][]int{}
-	var (
-		j int = 1
-		k int = b.tables
-	)
-	for i := b.rows - 1; i >= 0; i = i - batch {
-		if batch > i {
-			jobs = append(jobs, []int{j, i})
-			break
-		} else {
-			jobs = append(jobs, []int{j, batch})
-		}
-		if j >= k {
-			j = 1
-		} else {
-
-			j++
-		}
-	}
-	b.jobs = jobs
+	b.db.SetMaxOpenConns(connections)
 
 	return &b, nil
+}
+
+func sizeToFloat(s string) (float64, error) {
+	ns := s[:len(s)-2]
+	n, err := strconv.ParseFloat(ns, 64)
+	if err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
+func sizeToRows(s string) (int64, error) {
+	var m float64 = 1
+	re := regexp.MustCompile("(?i)[0-9]+[A-Za-z]+")
+	if !re.MatchString(s) {
+		return 0, fmt.Errorf("-size must be in format [number][size], e.g. 123gb")
+	}
+	size := strings.ToLower(s[len(s)-2:])
+
+	switch size {
+	case "mb":
+		m = 1000
+	case "gb":
+		m = 1000000
+	case "tb":
+		m = 1000000000
+	default:
+		return 0, fmt.Errorf("unknown -size %s. I can do mb, gb, and tb", s)
+	}
+
+	rows, err := sizeToFloat(s)
+	if err != nil {
+		return int64(rows), err
+	}
+
+	rows = rows * m
+
+	return int64(rows), nil
+}
+
+func randomString(r *rand.Rand) string {
+	var length int = 255
+	var characters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+
+	s := make([]rune, length)
+	for i := range s {
+		s[i] = characters[r.Intn(len(characters))]
+	}
+	return string(s)
+}
+
+func generateRow() string {
+	var limit = 2147483647
+	// 1000000000 x genRow ~= 1TB
+	r := rand.New(rand.NewSource(64))
+	b := strconv.Itoa(r.Intn(limit))
+	c := randomString(r)
+	d := randomString(r)
+	e := randomString(r)
+	f := randomString(r)
+	data := fmt.Sprintf("(%s,'%s','%s','%s','%s')", b, c, d, e, f)
+	return data
+}
+
+func (b *brim) createDatabase() error {
+	log.Printf("Creating database %s\n", b.database)
+	create := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", b.database)
+	err := b.insertRow(create)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (b *brim) createTable(name string) error {
+	tableName := b.database + "." + name
+	create := fmt.Sprintf(`DROP TABLE IF EXISTS %s; CREATE TABLE IF NOT EXISTS %s (
+a bigint(20) NOT NULL AUTO_INCREMENT,
+b int(11) NOT NULL,
+c char(255) NOT NULL,
+d char(255) NOT NULL,
+e char(255) NOT NULL,
+f char(255) NOT NULL,
+PRIMARY KEY (a),
+	INDEX (b)) ENGINE=%s;`, tableName, tableName, b.engine)
+	err := b.insertRow(create)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (b *brim) createTables() error {
+	log.Printf("Creating %d tables\n", b.tables)
+	for i := 0; i <= b.tables; i++ {
+		err := b.createTable(fmt.Sprintf("%s%d", b.tableBaseName, i))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (b *brim) insertRow(query string) error {
+	_, err := b.db.Exec(query)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func generateBatch(rows int64) string {
+	batch := make([]string, rows)
+	for i := range batch {
+		r := generateRow()
+		batch[i] = r
+	}
+
+	joinedBatch := strings.Join(batch, ",")
+	return joinedBatch
+}
+
+// Load table will generate a batch of data using generateRow and load the target table.
+func (b *brim) loadTable(tableID int, batchSize int64, rows <-chan int64, result chan<- int64) {
+	tableName := fmt.Sprintf("%s.%s%d", b.database, b.tableBaseName, tableID)
+	var query string = "INSERT INTO %s (b,c,d,e,f) VALUES %s"
+	data := generateBatch(batchSize)
+	row := fmt.Sprintf(query, tableName, data)
+	r, err := b.db.Exec(row)
+	if err != nil {
+		log.Fatal(err)
+	}
+	inserted, err := r.RowsAffected()
+	if err != nil {
+		log.Fatal(err)
+	}
+	result <- inserted
+}
+
+func (b *brim) load() {
+	var batch int64 = b.batch
+
+	rows := make(chan int64, b.rows)
+	result := make(chan int64, b.rows)
+
+	for t := 1; t <= b.tables; t++ {
+		go b.loadTable(t, batch, rows, result)
+	}
+
+	for j := int64(0); j <= b.rows; j += batch {
+		rows <- j
+		if j+batch > b.rows {
+			diff := (j + batch) - b.rows
+			batch += diff
+			log.Printf("Remaining rows for last batch: %d", batch)
+		}
+	}
+	close(rows)
+
+	for r := int64(0); r <= b.rows; r += batch {
+		<-result
+		if r+batch > b.rows {
+			diff := (r + batch) - b.rows
+			batch += diff
+			log.Printf("Remaining rows for last batch: %d", batch)
+		}
+	}
+
+}
+
+func (b *brim) countRows() {
+	var total int64 = 0
+	for t := 1; t <= b.tables; t++ {
+		var c int64 = 0
+		q := fmt.Sprintf("SELECT COUNT(*) FROM %s.%s%d", b.database, b.tableBaseName, t)
+		if err := b.db.QueryRow(q).Scan(&c); err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println(q, c)
+		total += c
+
+	}
+	log.Printf("Total rows: %d", total)
 }
 
 func (b *brim) run() error {
@@ -268,69 +305,67 @@ func (b *brim) run() error {
 		return err
 	}
 
-	log.Printf("Loading %d rows, into %d table(s), batch size of %d, over %d jobs and %d threads\n", b.rows, b.tables, b.batch, len(b.jobs), b.threads)
+	b.start = time.Now()
 
-	jobCount := len(b.jobs)
-	jobs := make(chan int, jobCount)
-	jobResults := make(chan int, jobCount)
+	log.Printf("Loading rows: %d, tables: %d, batch: %d, threads: %d\n", b.rows, b.tables, b.batch, b.threads)
 
-	for worker := 1; worker <= b.threads; worker++ {
-		go func(id int, jobs <-chan int, results chan<- int) {
-			for i := range jobs {
-				tableName := fmt.Sprintf("%s.%s%d", b.database, b.tableBaseName, id)
-				stmt, err := b.db.Prepare("INSERT INTO " + tableName + " (b,c,d,e,f) VALUES (?, ?, ?, ?, ?)")
-				if err != nil {
-					continue
-				}
-				defer stmt.Close()
-				b.loadTable(stmt, b.jobs[i][1])
-				results <- i
-			}
-		}(worker, jobs, jobResults)
-	}
+	b.load()
 
-	for j := 0; j <= jobCount-1; j++ {
-		jobs <- j
-	}
-	close(jobs)
-
-	for r := 0; r <= jobCount-1; r++ {
-		<-jobResults
-	}
+	log.Printf("Time: %s", time.Since(b.start))
 
 	return nil
 }
 
+func init() {
+	if runtime.GOOS == "linux" {
+		defaultSocketPath = "/run/mysqld/mysqld.sock"
+	} else {
+		defaultSocketPath = "/tmp/mysql.sock"
+	}
+
+	if _, err := os.Stat(defaultSocketPath); err != nil {
+		defaultSocketPath = ""
+	}
+	u, err := user.Current()
+	if err == nil {
+		defaultUserName = u.Username
+	} else {
+		defaultUserName = ""
+	}
+}
+
 func main() {
 	var (
-		host     = kingpin.Flag("host", "MariaDB hostname or IP address").Default("localhost").Envar("BRIM_HOST").String()
-		port     = kingpin.Flag("port", "MariaDB TCP/IP Port").Envar("BRIM_PORT").Int()
-		username = kingpin.Flag("username", "MariaDB username").Default("").Envar("BRIM_USER").String()
-		password = kingpin.Flag("password", "MariaDB username").Default("").Envar("BRIM_PASSWORD").String()
-		socket   = kingpin.Flag("socket", "Path to MariaDB server socket").Default("/run/mysqld/mysqld.sock").Envar("BRIM_SOCKET").String()
-		database = kingpin.Flag("database", "Database to use when creating tables").Default("brim").Envar("BRIM_DB").String()
-		engine   = kingpin.Flag("engine", "Engine to use when create tables").Default("INNODB").Envar("BRIM_ENGINE").String()
-		size     = kingpin.Flag("size", "Size of the dataset to be loaded across all tables e.g. 100MB, 123GB, 2.4TB").Default("").Envar("BRIM_SIZE").String()
-		rows     = kingpin.Flag("rows", "Total number of rows to be inserted across all tables. Each rows is around 1 Kilobyte").Envar("BRIM_ROWS").Int()
-		batch    = kingpin.Flag("batch", "Number of rows to insert per-batch").Envar("BRIM_BATCH").Int()
-		tables   = kingpin.Flag("tables", "Number of tables to distribute inserts between").Envar("BRIM_TABLES").Int()
-		threads  = kingpin.Flag("threads", "Number of concurrent threads to insert row batches").Envar("BRIM_THREADS").Int()
+		host        = kingpin.Flag("host", "MariaDB hostname or IP address").Short('h').Default("localhost").Envar("BRIM_HOST").String()
+		port        = kingpin.Flag("port", "MariaDB TCP/IP Port").Short('P').Envar("BRIM_PORT").Int()
+		username    = kingpin.Flag("user", "MariaDB username").Short('u').Default(defaultUserName).Envar("BRIM_USER").String()
+		password    = kingpin.Flag("password", "MariaDB password").Short('p').Default("").Envar("BRIM_PASSWORD").String()
+		socket      = kingpin.Flag("socket", "Path to MariaDB server socket").Default(defaultSocketPath).Envar("BRIM_SOCKET").String()
+		connections = kingpin.Flag("connections", "Max connections to the MariaDB Database server").Short('c').Envar("BRIM_CONNECTIONS").Int()
+		database    = kingpin.Flag("database", "Database to use when creating tables").Short('D').Default("brim").Envar("BRIM_DB").String()
+		engine      = kingpin.Flag("engine", "Engine to use when create tables").Default("INNODB").Envar("BRIM_ENGINE").String()
+		size        = kingpin.Flag("size", "Size of the dataset to be loaded across all tables e.g. 100MB, 123GB, 2.4TB").Short('s').Default("").Envar("BRIM_SIZE").String()
+		rows        = kingpin.Flag("rows", "Total number of rows to be inserted across all tables. Each rows is around 1 Kilobyte").Short('r').Envar("BRIM_ROWS").Int64()
+		batch       = kingpin.Flag("batch", "Number of rows to insert per-batch").Short('b').Envar("BRIM_BATCH").Int64()
+		tables      = kingpin.Flag("tables", "Number of tables to distribute inserts between").Short('t').Envar("BRIM_TABLES").Int()
+		threads     = kingpin.Flag("threads", "Number of concurrent threads to insert row batches").Envar("BRIM_THREADS").Int()
 	)
 
 	kingpin.Version(Version)
 	kingpin.CommandLine.UsageWriter(os.Stdout)
-	kingpin.HelpFlag.Short('h')
+	//kingpin.HelpFlag.Short('h')
 	kingpin.Parse()
 
-	b, err := NewBrim(*username, *password, *host, *port, *socket, *database, *engine, *size, *rows, *batch, *tables, *threads)
+	b, err := NewBrim(*username, *password, *host, *port, *connections, *socket, *database, *engine, *size, *rows, *batch, *tables, *threads)
 	if err != nil {
 		log.Fatalln(err)
 	}
 	defer b.db.Close()
 
-	err = b.run()
-	if err != nil {
+	if err = b.run(); err != nil {
 		log.Fatal(err)
 	}
+
+	b.countRows()
 
 }

--- a/brimming.go
+++ b/brimming.go
@@ -253,8 +253,7 @@ func (b *brim) loadTable(tableID int64, batchSize int64) {
 	}
 }
 
-func (b *brim) load() {
-
+func (b *brim) generateJobs() [][]int64 {
 	batches := [][]int64{}
 
 	var table int = 1
@@ -270,7 +269,11 @@ func (b *brim) load() {
 		batches = append(batches, []int64{int64(table), batch})
 		table++
 	}
+	return batches
+}
 
+func (b *brim) load() {
+	batches := b.generateJobs()
 	jobCount := int64(len(batches))
 
 	jobs := make(chan int64, jobCount)

--- a/brimming_test.go
+++ b/brimming_test.go
@@ -37,3 +37,9 @@ func TestSizeToRows(t *testing.T) {
 	}
 
 }
+
+func TestNewBrim(t *testing.T) {
+}
+
+func TestGenerateJobs(t *testing.T) {
+}

--- a/brimming_test.go
+++ b/brimming_test.go
@@ -18,7 +18,7 @@ func TestStrToFloat(t *testing.T) {
 }
 
 func TestSizeToRows(t *testing.T) {
-	expect := map[string]int{
+	expect := map[string]int64{
 		"2 thing": 0,
 		"100mb":   100000,
 		"123gb":   123000000,

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/alecthomas/kingpin v2.2.6+incompatible
-	github.com/go-sql-driver/mysql v1.7.0
+	github.com/go-sql-driver/mysql v1.7.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-sql-driver/mysql v1.7.0 h1:ueSltNNllEqE3qcWBTD0iQd3IpL/6U+mJxLkazJ7YPc=
 github.com/go-sql-driver/mysql v1.7.0/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
+github.com/go-sql-driver/mysql v1.7.1 h1:lUIinVbN1DY0xBg0eMOzmmtGoHwWBbvnWubQUrtU8EI=
+github.com/go-sql-driver/mysql v1.7.1/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
Rething? Rethink.

Anyway. Happy with the refactor, it's easier to read. But nothing has really changed other than using Int64 everywhere.

Updated the readme a bit and added a couple of default paths for Linux and Container/MacOS builds of MariaDB.

The connections flag can help with some tests where connections are limited or constrained by other processes.

Tables are now dropped by default and a handy count runs at the end.