### PR TITLE
Skip loads and a little test

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The default database is called brim. The user will need permissions to create, d
 * connections, limit how many connections are opened to MariaDB.
 * skip-drop, do not drop any pre-existing tables.
 * skip-count, do not run a `count(*)` on each loaded table at the end of a run.
+* skip-load, do not create any tables or insert any rows, useful for cleaning up residual tables.
 
 ## Data
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Alternatively specify the size of data you wish to insert, let's load 1TB:
 
 If you have go installed:
 
- go install github.com/rcbensley/brimming@latest
+    go install github.com/rcbensley/brimming@latest
 
 Otherwise checkout the package tarballs.
 

--- a/README.md
+++ b/README.md
@@ -11,17 +11,19 @@ Alternatively specify the size of data you wish to insert, let's load 1TB:
     brimming --size=1tb --threads=100 --tables=250
 
 ## Install
+
 If you have go installed:
 
-	go install github.com/rcbensley/brimming@latest
+ go install github.com/rcbensley/brimming@latest
 
 Otherwise checkout the package tarballs.
 
 ## Usage
+
 Other than the usual options like username, password, port etc, all options are related to loading data.
 Pay attention to the defaults being populated, which can be reviewed in `brimming --help`.
 
-The default database is called brim. The user will need permissions to create, drop, insert, select on all tables in database schema.
+The default database is called brim. The user will need permissions to create, drop, insert, select on all tables in this database schema, or whatever `--database` is configured to be.
 
 * rows, as mentioned above use either rows or size to specify how much data you wish to load. Internally this is an Int64 value, so the sky's the limit!
 * size, internally this is converted into a row count. Each row is roughly 1kb. The option requires a size value followed by the type of unit size. For example, to insert 100mb, use `--size=100mb`.
@@ -34,27 +36,26 @@ The default database is called brim. The user will need permissions to create, d
 * skip-count, do not run a `count(*)` on each loaded table at the end of a run.
 
 ## Data
-What is being loaded?
-Each row is just over 1KB, 1 billion rows will generate around 1TB of data, exluding indexes.
-Brimming does not use prepared statements. Just raw auto-committed, multi-value inserts.
+
+What is being loaded? Each row is just over 1KB of random data, 1 billion rows will generate around 1TB of data, exluding indexes.
+Brimming does not use prepared statements, just raw auto-committed, multi-value inserts.
 
 The tables are created in numerical order. If you are loading 10 tables, the tables brim1 to brim10 will be created, and dropped if they already exist (unless you are using `--skip-drop`).
 
 The table itself:
 
-	CREATE TABLE IF NOT EXISTS brim1 (
-	a bigint(20) NOT NULL AUTO_INCREMENT,
-	b int(11) NOT NULL,
-	c char(255) NOT NULL,
-	d char(255) NOT NULL,
-	e char(255) NOT NULL,
-	f char(255) NOT NULL,
-	PRIMARY KEY (a), INDEX (b)) ENGINE=InnoDB;
+    CREATE TABLE IF NOT EXISTS brim1 (
+    a bigint(20) NOT NULL AUTO_INCREMENT,
+    b int(11) NOT NULL,
+    c char(255) NOT NULL,
+    d char(255) NOT NULL,
+    e char(255) NOT NULL,
+    f char(255) NOT NULL,
+    PRIMARY KEY (a)) ENGINE=InnoDB;
 
 Quite simple. The column, a, is left to be populated by `AUTO_INCREMENT`. All other fields are populated with randomly generated data in batches.
 
-
 ## Considerations
-The default `max_packet_allowed` is about 16MB, so increase this as you increase your batch size. A warning will be generated if this value is exceeded.
-Do you have the general log or binary logging enabled?
 
+* The default `max_packet_allowed` is about 16MB, so increase this as you increase your batch size. A warning will be generated if this value is exceeded.
+* Do you have the general log or binary logging enabled?

--- a/brimming_test.go
+++ b/brimming_test.go
@@ -48,7 +48,7 @@ type TestGenerateJobsData struct {
 
 func TestGenerateJobs(t *testing.T) {
 	inputs := []TestGenerateJobsData{
-		{b: brim{rows: 1234, batch: 1000, tables: 10}, jobs: [][]int64{}},
+		{b: brim{rows: 864, batch: 1000, tables: 4}, jobs: [][]int64{[]int64{1, 216}, []int64{1, 216}, []int64{1, 216}, []int64{1, 216}}},
 	}
 
 	for _, b := range inputs {

--- a/brimming_test.go
+++ b/brimming_test.go
@@ -38,9 +38,6 @@ func TestSizeToRows(t *testing.T) {
 
 }
 
-func TestNewBrim(t *testing.T) {
-}
-
 type TestGenerateJobsData struct {
 	b    brim
 	jobs [][]int64
@@ -48,7 +45,8 @@ type TestGenerateJobsData struct {
 
 func TestGenerateJobs(t *testing.T) {
 	inputs := []TestGenerateJobsData{
-		{b: brim{rows: 864, batch: 1000, tables: 4}, jobs: [][]int64{[]int64{1, 216}, []int64{1, 216}, []int64{1, 216}, []int64{1, 216}}},
+		{b: brim{rows: 864, batch: 1000, tables: 4}, jobs: [][]int64{{1, 216}, {1, 216}, {1, 216}, {1, 216}}},
+		{b: brim{rows: 100, batch: 1000, tables: 3}, jobs: [][]int64{{1, 34}, {1, 33}, {1, 33}}},
 	}
 
 	for _, b := range inputs {

--- a/brimming_test.go
+++ b/brimming_test.go
@@ -41,5 +41,25 @@ func TestSizeToRows(t *testing.T) {
 func TestNewBrim(t *testing.T) {
 }
 
+type TestGenerateJobsData struct {
+	b    brim
+	jobs [][]int64
+}
+
 func TestGenerateJobs(t *testing.T) {
+	inputs := []TestGenerateJobsData{
+		{b: brim{rows: 1234, batch: 1000, tables: 10}, jobs: [][]int64{}},
+	}
+
+	for _, b := range inputs {
+		var sum int64 = 0
+		batch := b.b.generateJobs()
+		for _, i := range batch {
+			sum += i[1]
+		}
+		if sum != b.b.rows {
+			t.Fatalf("Expected total row count of %d, got %d", b.b.rows, sum)
+		}
+
+	}
 }


### PR DESCRIPTION
Split create and drop tables.
Refactored create and drop tables.
Added --skip-load to cleanup tables.
Removed index from column, b.
If the batch size is larger than the rows per-table, then the batch size is reduced.